### PR TITLE
noah/syn-198-find-all-errors-occurring-in-translation-starter-app

### DIFF
--- a/app/api/db/jobs/route.ts
+++ b/app/api/db/jobs/route.ts
@@ -1,0 +1,36 @@
+import { getJobs } from '@/app/supabase-server';
+import { Job } from '@/types/db';
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  if (req.method !== 'GET') {
+    return NextResponse.json({ success: false, message: `Method not allowed` });
+  }
+
+  try {
+    const jobs = await getJobs();
+
+    console.log('api/db/jobs: ', jobs?.length);
+
+    if (!jobs) {
+      return NextResponse.json({
+        success: false,
+        message: `Error fetching jobs`
+      });
+    }
+
+    const jobsToReturn = jobs.filter((job) => !job.is_deleted);
+
+    return NextResponse.json({
+      success: true,
+      data: jobsToReturn
+    });
+  } catch (error) {
+    console.error('Error:', error);
+    return NextResponse.json({
+      success: false,
+      message: `Error fetching jobs`,
+      error
+    });
+  }
+}

--- a/app/api/db/update-job-by-transcription-id/route.ts
+++ b/app/api/db/update-job-by-transcription-id/route.ts
@@ -9,12 +9,12 @@ export async function POST(req: Request) {
   const { transcriptionId, updatedFields } = await req.json();
 
   try {
-    const jobs = await updateJobByTranscriptionId(
+    const updatedJob = await updateJobByTranscriptionId(
       transcriptionId,
       updatedFields
     );
 
-    if (!jobs || jobs.length === 0) {
+    if (!updatedJob || updatedJob.length === 0) {
       return NextResponse.json({
         success: false
       });
@@ -22,7 +22,7 @@ export async function POST(req: Request) {
 
     return NextResponse.json({
       success: true,
-      data: jobs[0]
+      data: updatedJob[0]
     });
   } catch (error) {
     console.error('Error:', error);

--- a/app/api/db/update-job/route.ts
+++ b/app/api/db/update-job/route.ts
@@ -9,8 +9,6 @@ export async function POST(req: Request) {
   const { jobId, updatedFields } = await req.json();
 
   try {
-    console.log('updating job: ', { jobId, updatedFields });
-
     const jobs = await updateJob(jobId, updatedFields);
 
     if (!jobs || jobs.length === 0) {

--- a/app/api/transcribe/webhook/route.ts
+++ b/app/api/transcribe/webhook/route.ts
@@ -34,7 +34,8 @@ export async function POST(req: Request) {
       body: JSON.stringify({
         transcriptionId: result.request_id,
         updatedFields: {
-          transcript
+          transcript,
+          source_language: transcript[0].language
         }
       })
     }

--- a/app/api/transcribe/webhook/route.ts
+++ b/app/api/transcribe/webhook/route.ts
@@ -8,7 +8,6 @@ export async function OPTIONS(req: Request) {
 }
 
 export async function POST(req: Request) {
-  console.log('in transcribe/webhook');
   if (req.method !== 'POST') {
     return new Response('Method Not Allowed', {
       headers: { Allow: 'POST' },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,8 @@
-import { getCreditBalance, getSession, getJobs } from '@/app/supabase-server';
+import {
+  getCreditBalance,
+  getSession,
+  getUserDetails
+} from '@/app/supabase-server';
 import JobGrid from '@/components/feature-playground/ui/JobGrid';
 import MediaInput from '@/components/feature-playground/ui/MediaInput';
 import PageHeader from '@/components/ui/Display/PageHeader';
@@ -6,10 +10,10 @@ import { Flex, Stack } from '@chakra-ui/react';
 
 export default async function HomePage() {
   // Grab data from db
-  const [session, creditBalance, jobs] = await Promise.all([
+  const [session, creditBalance, user] = await Promise.all([
     getSession(),
     getCreditBalance(),
-    getJobs()
+    getUserDetails()
   ]);
 
   // Page content
@@ -18,8 +22,6 @@ export default async function HomePage() {
   const tag = `Beta`;
 
   const creditsAvailable = creditBalance.remaining > 0;
-
-  const jobsToDisplay = jobs?.filter((job) => !job.is_deleted);
 
   return (
     <Flex
@@ -38,7 +40,7 @@ export default async function HomePage() {
           className="items-center text-center"
         />
         <MediaInput session={session} creditsAvailable={creditsAvailable} />
-        {session && jobsToDisplay && <JobGrid jobs={jobsToDisplay} />}
+        {session && user && <JobGrid userId={user.id} />}
       </Stack>
     </Flex>
   );

--- a/app/supabase-server.ts
+++ b/app/supabase-server.ts
@@ -1,6 +1,7 @@
 import { JobStatus } from '@/types/db';
 import { Database } from '@/types_db';
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
+import { createClient } from '@supabase/supabase-js';
 import { cookies } from 'next/headers';
 import { cache } from 'react';
 
@@ -177,24 +178,27 @@ export async function insertJob() {
 
 export async function updateJob(jobId: string, updatedFields: any) {
   const supabase = createServerSupabaseClient();
-  const { data, error } = await supabase
-    .from('jobs')
-    .update({ ...updatedFields })
-    .eq('id', jobId)
-    .select();
-
-  if (error) {
-    console.log(error.message);
+  try {
+    const { data: updatedJob } = await supabase
+      .from('jobs')
+      .update({ ...updatedFields })
+      .eq('id', jobId)
+      .select();
+    return updatedJob;
+  } catch (error) {
+    console.log('Error: ', error);
+    return [];
   }
-  console.log('data: ', data);
-  return data ?? [];
 }
 
 export async function updateJobByOriginalVideoUrl(
   originalVideoUrl: string,
   updatedFields: any
 ) {
-  const supabase = createServerSupabaseClient();
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+  const supabaseServiceRoleKey = process.env
+    .SUPABASE_SERVICE_ROLE_KEY as string;
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
   const { data, error } = await supabase
     .from('jobs')
     .update({ ...updatedFields })
@@ -204,7 +208,6 @@ export async function updateJobByOriginalVideoUrl(
   if (error) {
     console.log(error.message);
   }
-  console.log('data: ', data);
   return data ?? [];
 }
 
@@ -212,16 +215,20 @@ export async function updateJobByTranscriptionId(
   transcriptionId: string,
   updatedFields: any
 ) {
-  const supabase = createServerSupabaseClient();
-  const { data, error } = await supabase
-    .from('jobs')
-    .update({ ...updatedFields })
-    .eq('transcription_id', transcriptionId)
-    .select();
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+  const supabaseServiceRoleKey = process.env
+    .SUPABASE_SERVICE_ROLE_KEY as string;
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+  try {
+    const { data: updatedJob } = await supabase
+      .from('jobs')
+      .update({ ...updatedFields })
+      .eq('transcription_id', transcriptionId)
+      .select();
 
-  if (error) {
-    console.log(error.message);
+    return updatedJob;
+  } catch (error) {
+    console.log('Error: ', error);
+    return [];
   }
-  console.log('data: ', data);
-  return data ?? [];
 }

--- a/components/feature-playground/ui/JobGrid/JobGrid.tsx
+++ b/components/feature-playground/ui/JobGrid/JobGrid.tsx
@@ -1,19 +1,31 @@
 'use client';
 
 import JobGridItem from './JobGridItem';
+import JobGridLoading from './JobGridLoading';
 import PageNavigator from '@/components/ui/PageNavigator';
+import useJobData from '@/hooks/useJobData';
 import { Job } from '@/types/db';
 import { sortByCreatedAt } from '@/utils/helpers';
 import { Stack, Flex, Grid } from '@chakra-ui/react';
 import { FC, useState } from 'react';
 
 interface Props {
-  jobs: Job[];
+  userId: string;
 }
 
-const JobGrid: FC<Props> = ({ jobs }) => {
+const JobGrid: FC<Props> = ({ userId }) => {
+  const { jobs, loading, error } = useJobData(userId);
+
   const pageSize = 6;
   const [offset, setOffset] = useState(0);
+
+  if (loading) {
+    return <JobGridLoading />;
+  }
+
+  if (error) {
+    return <div>Error fetching jobs</div>;
+  }
 
   const numJobs = jobs.length;
   const pages = Math.ceil(numJobs / pageSize);

--- a/components/feature-playground/ui/JobGrid/JobGridItem/ExpandedModal.tsx
+++ b/components/feature-playground/ui/JobGrid/JobGridItem/ExpandedModal.tsx
@@ -1,6 +1,7 @@
 import DeleteModal from './DeleteModal';
 import VideoPlayer from '@/components/ui/VideoPlayer';
-import { Job } from '@/types/db';
+import { languages } from '@/data/languages';
+import { Job, Transcript } from '@/types/db';
 import {
   Modal,
   ModalContent,
@@ -33,7 +34,6 @@ const Detail = (props: { title: string; value: string }) => {
     fallback: false // return false on the server, and re-evaluate on the client side
   });
 
-  console.log('props: ', props);
   return (
     <Flex
       direction={isLargerThan640 ? 'row' : 'column'}
@@ -101,6 +101,20 @@ const ExpandedModal = ({ job, isOpen, onClose }: Props) => {
     fallback: false // return false on the server, and re-evaluate on the client side
   });
 
+  const transcript = job.transcript as Transcript;
+
+  const extractedTranscript = transcript
+    ? transcript.map((item) => item.transcription).join(' ')
+    : '';
+
+  const sourceLanguage = languages.find(
+    (language) => language.code === job.source_language
+  );
+
+  const targetLanguage = languages.find(
+    (language) => language.code === job.target_language
+  );
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalContent
@@ -119,11 +133,29 @@ const ExpandedModal = ({ job, isOpen, onClose }: Props) => {
               <Detail title="Created" value={timeStamp} />
               <Detail title="Job ID" value={job.id} />
             </Flex>
+            <Flex gap={4}>
+              <Detail
+                title="Source Language"
+                value={
+                  sourceLanguage
+                    ? sourceLanguage.name
+                    : (job.source_language as string)
+                }
+              />
+              <Detail
+                title="Target Language"
+                value={
+                  targetLanguage
+                    ? targetLanguage.name
+                    : (job.target_language as string)
+                }
+              />
+            </Flex>
             <Flex justifyContent={'space-between'}>
               <Flex gap={'2'}>
                 <Button
                   onClick={() => setShow('translated-video')}
-                  variant={show === 'translated-video' ? 'outline' : 'solid'}
+                  variant={show === 'original-video' ? 'solid' : 'outline'}
                 >
                   <Tooltip hasArrow label="Lip synced video">
                     <Flex w="full" h="full" alignItems="center">
@@ -169,6 +201,7 @@ const ExpandedModal = ({ job, isOpen, onClose }: Props) => {
                 </Tooltip>
               </Button>
             </Flex>
+            <Flex></Flex>
             {url ? (
               <VideoPlayer key={`${job.id}-${url}`} url={url} />
             ) : (
@@ -187,6 +220,18 @@ const ExpandedModal = ({ job, isOpen, onClose }: Props) => {
                 </Text>
               </Flex>
             )}
+            <Stack p={4} bgColor="blackAlpha.200" rounded="md">
+              <Text fontWeight="bold" fontSize="md">
+                Transcript
+              </Text>
+              <Flex maxH={120} overflow={'scroll'}>
+                <Text fontSize="sm">
+                  {show === 'original-video'
+                    ? extractedTranscript
+                    : job.translated_text}
+                </Text>
+              </Flex>
+            </Stack>
           </Stack>
         </ModalBody>
       </ModalContent>

--- a/components/feature-playground/ui/JobGrid/JobGridItem/ExpandedModal.tsx
+++ b/components/feature-playground/ui/JobGrid/JobGridItem/ExpandedModal.tsx
@@ -2,6 +2,7 @@ import DeleteModal from './DeleteModal';
 import VideoPlayer from '@/components/ui/VideoPlayer';
 import { languages } from '@/data/languages';
 import { Job, Transcript } from '@/types/db';
+import { removeEdgeParentheses } from '@/utils/helpers';
 import {
   Modal,
   ModalContent,
@@ -115,6 +116,11 @@ const ExpandedModal = ({ job, isOpen, onClose }: Props) => {
     (language) => language.code === job.target_language
   );
 
+  const showTranscript =
+    show === 'original-video'
+      ? Boolean(extractedTranscript)
+      : Boolean(job.translated_text);
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalContent
@@ -220,18 +226,20 @@ const ExpandedModal = ({ job, isOpen, onClose }: Props) => {
                 </Text>
               </Flex>
             )}
-            <Stack p={4} bgColor="blackAlpha.200" rounded="md">
-              <Text fontWeight="bold" fontSize="md">
-                Transcript
-              </Text>
-              <Flex maxH={120} overflow={'scroll'}>
-                <Text fontSize="sm">
-                  {show === 'original-video'
-                    ? extractedTranscript
-                    : job.translated_text}
+            {showTranscript && (
+              <Stack p={4} bgColor="blackAlpha.200" rounded="md">
+                <Text fontWeight="bold" fontSize="md">
+                  Transcript
                 </Text>
-              </Flex>
-            </Stack>
+                <Flex maxH={120} overflow={'scroll'}>
+                  <Text fontSize="sm">
+                    {show === 'original-video'
+                      ? extractedTranscript
+                      : removeEdgeParentheses(job.translated_text || '')}
+                  </Text>
+                </Flex>
+              </Stack>
+            )}
           </Stack>
         </ModalBody>
       </ModalContent>

--- a/components/feature-playground/ui/JobGrid/JobGridLoading.tsx
+++ b/components/feature-playground/ui/JobGrid/JobGridLoading.tsx
@@ -1,4 +1,4 @@
-import { AspectRatio, Box, Grid, Stack } from '@chakra-ui/react';
+import { AspectRatio, Grid, Flex, Stack } from '@chakra-ui/react';
 
 export default function JobGridLoading() {
   return (
@@ -11,19 +11,30 @@ export default function JobGridLoading() {
       ]}
       gap={4}
       w={'100%'}
+      maxW={'1200'}
     >
-      {[...Array(6)].map((_, i) => (
-        <Box
-          width={'full'}
+      {[...Array(8)].map((_, i) => (
+        <Stack
           key={i}
-          bgColor={'blackAlpha.400'}
-          bgGradient="linear(to-b, whiteAlpha.200, transparent)"
+          bgColor="blackAlpha.400"
+          bgGradient="linear(to-b, whiteAlpha.100, transparent)"
+          transition="transform 0.2s"
+          _hover={{
+            borderColor: 'whiteAlpha.600',
+            bgGradient: 'linear(to-b, whiteAlpha.200, transparent)'
+          }}
+          rounded={'md'}
+          p={2}
+          position={'relative'}
+          w="full"
           className="animate-pulse"
         >
-          <AspectRatio ratio={16 / 9}>
+          <AspectRatio ratio={16 / 9} bg="whiteAlpha.100">
             <Stack w="full" h="full" p={4}></Stack>
           </AspectRatio>
-        </Box>
+          <Flex bg="whiteAlpha.100" w="full" h={4} rounded="md" />
+          <Flex bg="whiteAlpha.100" w="50%" h={4} rounded="md" />
+        </Stack>
       ))}
     </Grid>
   );

--- a/components/feature-playground/ui/JobGrid/JobGridLoading.tsx
+++ b/components/feature-playground/ui/JobGrid/JobGridLoading.tsx
@@ -13,7 +13,7 @@ export default function JobGridLoading() {
       w={'100%'}
       maxW={'1200'}
     >
-      {[...Array(8)].map((_, i) => (
+      {[...Array(6)].map((_, i) => (
         <Stack
           key={i}
           bgColor="blackAlpha.400"

--- a/components/feature-playground/ui/MediaInput/MediaInput.tsx
+++ b/components/feature-playground/ui/MediaInput/MediaInput.tsx
@@ -143,7 +143,6 @@ const MediaInput: FC<Props> = ({ session, creditsAvailable }) => {
   }
 
   async function uploadFile(file: File, filePath: string) {
-    console.log('in uploadFile - file: ', file);
     const { data, error } = await supabase.storage
       .from('translation')
       .upload(filePath, file, {
@@ -159,8 +158,6 @@ const MediaInput: FC<Props> = ({ session, creditsAvailable }) => {
       console.error('No data returned from upload');
       return;
     }
-
-    console.log('data: ', data);
 
     const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/translation/${data.path}`;
 

--- a/components/feature-playground/ui/MediaInput/MediaInput.tsx
+++ b/components/feature-playground/ui/MediaInput/MediaInput.tsx
@@ -7,6 +7,7 @@ import Info from '@/components/ui/Display/Info';
 import FileDrop from '@/components/ui/Input/FileDrop';
 import Selector from '@/components/ui/Input/Selector';
 import { SignUpModal } from '@/components/ui/Modals';
+import { languages } from '@/data/languages';
 import { Job, JobStatus } from '@/types/db';
 import loadFfmpeg from '@/utils/load-ffmpeg';
 import { checkIfValidYoutubeUrl } from '@/utils/regex';
@@ -27,11 +28,6 @@ import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { Session } from '@supabase/auth-helpers-nextjs';
 import { FC, useCallback, useEffect, useState, useRef } from 'react';
 import { HiSparkles } from 'react-icons/hi';
-
-interface Language {
-  name: string;
-  code: string;
-}
 
 interface Props {
   session: Session | null;
@@ -79,29 +75,6 @@ const MediaInput: FC<Props> = ({ session, creditsAvailable }) => {
       `Make sure there's a face in the first frame of the video`
     ]
   };
-
-  const languages: Language[] = [
-    { name: 'Mandarin Chinese', code: 'zh' },
-    { name: 'Spanish', code: 'es' },
-    { name: 'English', code: 'en' },
-    { name: 'Hindi', code: 'hi' },
-    { name: 'Arabic', code: 'ar' },
-    { name: 'Portuguese', code: 'pt' },
-    { name: 'Bengali (Bangla)', code: 'bn' },
-    { name: 'Russian', code: 'ru' },
-    { name: 'Urdu', code: 'ur' },
-    { name: 'French', code: 'fr' },
-    { name: 'Punjabi', code: 'pa' },
-    { name: 'Japanese', code: 'ja' },
-    { name: 'German', code: 'de' },
-    { name: 'Javanese', code: 'jv' },
-    { name: 'Wu Chinese (Shanghainese)', code: 'wuu' },
-    { name: 'Telugu', code: 'te' },
-    { name: 'Vietnamese', code: 'vi' },
-    { name: 'Marathi', code: 'mr' },
-    { name: 'Tamil', code: 'ta' },
-    { name: 'Turkish', code: 'tr' }
-  ];
 
   // Close sign up modal if user is signed in
   useEffect(() => {

--- a/components/feature-usage/ui/UsageTable/UsageTable.tsx
+++ b/components/feature-usage/ui/UsageTable/UsageTable.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import UsageTableLoading from './UsageTableLoading';
 import StatusTag from '@/components/ui/Display/StatusTag';
 import PageNavigator from '@/components/ui/PageNavigator';
 import useJobData from '@/hooks/useJobData';
@@ -49,7 +50,7 @@ const UsageTable: FC<Props> = ({ userId }) => {
   const [offset, setOffset] = useState(0);
 
   if (loading) {
-    return <div>Loading...</div>;
+    return <UsageTableLoading />;
   }
 
   if (error) {

--- a/components/feature-usage/ui/UsageTable/UsageTable.tsx
+++ b/components/feature-usage/ui/UsageTable/UsageTable.tsx
@@ -53,7 +53,7 @@ const UsageTable: FC<Props> = ({ userId }) => {
   }
 
   if (error) {
-    return <div>Error fetching jobs: {error.message}</div>;
+    return <div>Error fetching jobs</div>;
   }
 
   if (!jobs.length) {

--- a/components/feature-usage/ui/UsageTable/UsageTableLoading.tsx
+++ b/components/feature-usage/ui/UsageTable/UsageTableLoading.tsx
@@ -1,0 +1,29 @@
+import { Flex, Stack } from '@chakra-ui/react';
+
+export default function UsageTableLoading() {
+  return (
+    <Stack
+      w="full"
+      h="full"
+      bg="blackAlpha.400"
+      gap={'4'}
+      p={'4'}
+      rounded={'md'}
+    >
+      <Stack h="full">
+        {[...Array(10)].map((_, i) => {
+          return (
+            <Flex
+              key={i}
+              bg="whiteAlpha.100"
+              w="full"
+              h="10"
+              rounded="md"
+              className="animate-pulse"
+            />
+          );
+        })}
+      </Stack>
+    </Stack>
+  );
+}

--- a/components/ui/Display/StatusTag/StatusTag.tsx
+++ b/components/ui/Display/StatusTag/StatusTag.tsx
@@ -18,9 +18,7 @@ const StatusBox: FC<Props> = ({ status }) => {
     case 'cloning':
     case 'synthesizing':
     case 'synchronizing':
-    case 'completed':
-    case 'failed':
-      color = 'yellow.900';
+      color = 'yellow.600';
       break;
     case 'completed':
       color = 'green.600';

--- a/data/languages.ts
+++ b/data/languages.ts
@@ -1,0 +1,39 @@
+interface Language {
+  name: string;
+  code: string;
+}
+
+export const languages = [
+  { name: 'English', code: 'en' },
+  { name: 'Mandarin Chinese', code: 'zh' },
+  { name: 'Hindi', code: 'hi' },
+  { name: 'Spanish', code: 'es' },
+  { name: 'French', code: 'fr' },
+  { name: 'Arabic', code: 'ar' },
+  { name: 'Portuguese', code: 'pt' },
+  { name: 'Russian', code: 'ru' },
+  { name: 'Indonesian', code: 'id' },
+  { name: 'German', code: 'de' },
+  { name: 'Japanese', code: 'ja' },
+  { name: 'Korean', code: 'ko' },
+  { name: 'Vietnamese', code: 'vi' },
+  { name: 'Italian', code: 'it' },
+  { name: 'Dutch', code: 'nl' },
+  { name: 'Turkish', code: 'tr' },
+  { name: 'Polish', code: 'pl' },
+  { name: 'Swedish', code: 'sv' },
+  { name: 'Filipino', code: 'tl' },
+  { name: 'Malay', code: 'ms' },
+  { name: 'Romanian', code: 'ro' },
+  { name: 'Ukrainian', code: 'uk' },
+  { name: 'Greek', code: 'el' },
+  { name: 'Czech', code: 'cs' },
+  { name: 'Danish', code: 'da' },
+  { name: 'Finnish', code: 'fi' },
+  { name: 'Bulgarian', code: 'bg' },
+  { name: 'Croatian', code: 'hr' },
+  { name: 'Slovak', code: 'sk' },
+  { name: 'Hungarian', code: 'hu' },
+  { name: 'Norwegian', code: 'no' },
+  { name: 'Tamil', code: 'ta' }
+];

--- a/supabase/migrations/20230530034630_init.sql
+++ b/supabase/migrations/20230530034630_init.sql
@@ -106,6 +106,10 @@ CREATE TABLE jobs (
   is_deleted BOOLEAN DEFAULT FALSE,
   user_id UUID REFERENCES auth.users NOT NULL
 );
+ALTER TABLE jobs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Enable select for authenticated users" ON jobs FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Enable update for authenticated users" ON jobs FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Enable insert for authenticated users" ON jobs FOR INSERT USING (auth.uid() = user_id);
 
 -- Realtime subscriptions
 DROP PUBLICATION IF EXISTS supabase_realtime;

--- a/utils/clone-voice.ts
+++ b/utils/clone-voice.ts
@@ -19,7 +19,7 @@ export default async function cloneVoice(job: Job, onFail: OnFailedJob) {
     await updateJob(job, updatedFields, onFail);
   } catch (error) {
     const updatedFields = {
-      voice_id: `JNMatQzwX6yZ3J1EZeo7`
+      voice_id: `9F4C8ztpNUmXkdDDbz3J`
     };
     await updateJob(job, updatedFields, onFail);
   }

--- a/utils/deleteVoice.ts
+++ b/utils/deleteVoice.ts
@@ -3,17 +3,17 @@ import updateJob from './update-job';
 import { Job, OnFailedJob } from '@/types/db';
 
 export default async function deleteVoice(job: Job) {
+  const updatedFields = {
+    voice_id: null
+  };
   // Don't delete the default voice
-  if (job.voice_id && job.voice_id === 'JNMatQzwX6yZ3J1EZeo7') {
+  if (job.voice_id && job.voice_id === '9F4C8ztpNUmXkdDDbz3J') {
+    await updateJob(job, updatedFields);
     return;
   }
   try {
     const path = `/api/delete-voice`;
     await apiRequest(path, { voiceId: job.voice_id });
-
-    const updatedFields = {
-      voice_id: null
-    };
 
     await updateJob(job, updatedFields);
   } catch (error) {

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -70,6 +70,10 @@ export const sortByCreatedAt = (array: any[]) => {
   });
 };
 
+export const removeEdgeParentheses = (s: string): string => {
+  return s.replace(/^\(|\)$/g, '');
+};
+
 export const isValidUrl = (url: string) => {
   try {
     new URL(url);

--- a/utils/sythesis-speech.ts
+++ b/utils/sythesis-speech.ts
@@ -8,7 +8,7 @@ export default async function synthesisSpeech(job: Job, onFail: OnFailedJob) {
     const path = '/api/speech-synthesis';
     const synthesis = await apiRequest(path, {
       text: job.translated_text,
-      voiceId: job.voice_id
+      voiceId: job.voice_id || '9F4C8ztpNUmXkdDDbz3J'
     });
 
     const { data: translatedAudioUrl } = await synthesis;


### PR DESCRIPTION
- Updated home page to pass userId to JobGrid instead of jobs. The jobs are fetched in the JobGrid now
- Updated logic for updateJob, updateJobByOriginalVideoUrl and updateJobByTranscriptionId in supabase-server file
- Updated JobGrid to use useJobData hook for grabbing job
- Fixed logic with colors for tags in StatusTag component
- Updated logic for fetching jobs
- Added RLS policies for jobs table to the supabase migration file
- Updated default voice_id for clone-voice util
- Added default voice_id as fallback in synthesisSpeech util function
- Created api/db/jobs route for grabbing jobs
- Updated error view for UsageTable component
- Updated transcribe/webhook api call to save source_language
- Updated ExpandedModal component to display the source language, target language and transcript for each video.
- Improved UI for JobGridLoading component
- Created UsageTableLoading component.
- Moved langauges into a new data folder.
- Updated MediaInput component to import languages from seperate file.
- Updated UsageTable component to use UsageTableLoading component.
- Added helper function for removing parentheses at the beginning and end of a string.
