### PR TITLE
Update Sync Lip API to use sync-1.5-beta

### DIFF
--- a/app/api/lip-sync/route.ts
+++ b/app/api/lip-sync/route.ts
@@ -67,7 +67,8 @@ export async function POST(req: Request) {
         audioUrl,
         videoUrl,
         synergize: true,
-        webhookUrl: `${baseUrl}/api/lip-sync/webhook`
+        webhookUrl: `${baseUrl}/api/lip-sync/webhook`,
+        model: 'sync-1.5-beta'
       })
     });
 


### PR DESCRIPTION
- Updated lip-sync api call to include the model param for setting the model to sync-1.5-beta